### PR TITLE
find lcov from active project (support multiple projects)

### DIFF
--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -8,7 +8,9 @@ let lcovWatcher;
 export async function showCoverage(editor, subscriptions) {
   try {
     const projectPaths = atom.project.getPaths();
-    const lcovPath = await findLcovFilePath(projectPaths[0]);
+    const filePath = editor.getPath();
+    const [targetProjectPath] = projectPaths.filter((p) => filePath.indexOf(p) > -1);
+    const lcovPath = await findLcovFilePath(targetProjectPath);
     const lcovInfo = await readLcovFile(lcovPath);
     const records = parseLcovFile(lcovInfo);
     const results = findLcovInfo(editor.getPath(), records);


### PR DESCRIPTION
Right now, the project path used is `getPaths()[0]` which doesn't work if there are more than one project open.


nice package btw 💯 